### PR TITLE
Allow setting liferay user UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM azul/zulu-openjdk-alpine:11
 
-RUN addgroup -S liferay && adduser -S liferay -G liferay && \
+ARG LIFERAY_UID
+
+RUN addgroup -S liferay && adduser -S liferay -G liferay -u ${LIFERAY_UID:-100} && \
     apk --update --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/main/ add \
     gcompat
 

--- a/Dockerfile.gradle
+++ b/Dockerfile.gradle
@@ -1,6 +1,8 @@
 FROM azul/zulu-openjdk-alpine:11
 
-RUN addgroup -S liferay && adduser -S liferay -G liferay && \
+ARG LIFERAY_UID
+
+RUN addgroup -S liferay && adduser -S liferay -G liferay -u ${LIFERAY_UID:-100} && \
     apk --update --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/main/ add \
     gcompat
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
-version: '2.1'
+version: "3"
+
 services:
   gradle:
     build:
-      dockerfile: Dockerfile-gradle
+      dockerfile: Dockerfile.gradle
       context: .
       args:
         TARGET_ENV: local
+        LIFERAY_UID: $UID
     volumes:
       - ./modules:/home/liferay/modules
       - lfr_osgi_modules:/home/liferay/bundles/osgi/modules
@@ -15,6 +17,7 @@ services:
       context: .
       args:
         TARGET_ENV: local
+        LIFERAY_UID: $UID
     environment:
       - LIFERAY_JPDA_ENABLED=true
     ports:
@@ -23,5 +26,6 @@ services:
       - 11311:11311
     volumes:
       - lfr_osgi_modules:/home/liferay/bundles/osgi/modules
+
 volumes:
   lfr_osgi_modules:


### PR DESCRIPTION
This is useful on Linux; otherwise we end up with different UIDs
in the container and outside of the container, and chaos ensues.
make sure to 'export UID' when running on Linux before running
Compose up.